### PR TITLE
Port codebase to Rust 2021 and modern stable Rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,16 +8,17 @@ homepage = "http://jneem.github.io/regex-dfa"
 repository = "http://github.com/jneem/regex-dfa"
 readme = "README.md"
 license = "MIT/Apache-2.0"
+edition = "2021"
+autobenches = false
 
 [dependencies]
 itertools = "0.4"
-lazy_static = "0.1"
-memchr = "0.1"
-num-traits = "0.1"
+lazy_static = "1.0"
+memchr = "2.0"
+num-traits = "0.2"
 range-map = "0.1.5"
-refinery = "0.1"
 regex-syntax = "0.2"
-utf8-ranges = "0.1"
+utf8-ranges = "1.0"
 
 [dev-dependencies]
 matches = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,10 +43,6 @@ bench = true
 name = "examples"
 path = "tests/matches.rs"
 
-[[test]]
-name = "crate"
-path = "src/lib.rs"
-
 [profile.bench]
 debug = true
 lto = true

--- a/src/dfa/minimizer.rs
+++ b/src/dfa/minimizer.rs
@@ -6,10 +6,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use dfa::{Dfa, RetTrait};
-use nfa::{Accept, StateIdx, StateSet};
+use crate::dfa::{Dfa, RetTrait};
+use crate::nfa::{Accept, StateIdx, StateSet};
+use crate::partition::Partition;
 use range_map::{RangeMultiMap, RangeSet};
-use refinery::Partition;
 use std::collections::{HashSet, HashMap};
 
 pub struct Minimizer {

--- a/src/dfa/mod.rs
+++ b/src/dfa/mod.rs
@@ -10,22 +10,22 @@ mod trie;
 mod prefix_searcher;
 mod minimizer;
 
-use dfa::minimizer::Minimizer;
-use dfa::prefix_searcher::PrefixSearcher;
-use graph::Graph;
-use look::Look;
+use crate::dfa::minimizer::Minimizer;
+use crate::dfa::prefix_searcher::PrefixSearcher;
+use crate::graph::Graph;
+use crate::look::Look;
 use itertools::Itertools;
-use nfa::{Accept, StateIdx};
+use crate::nfa::{Accept, StateIdx};
+use crate::partition::Partition;
 use range_map::{RangeMap, RangeMultiMap};
-use refinery::Partition;
-use runner::program::TableInsts;
+use crate::runner::program::TableInsts;
 use std;
 use std::fmt::{Debug, Formatter};
 use std::hash::Hash;
 use std::mem;
 use std::u32;
 
-pub use dfa::prefix_searcher::PrefixPart;
+pub use crate::dfa::prefix_searcher::PrefixPart;
 
 #[derive(Clone, PartialEq, Debug)]
 pub struct State<Ret> {
@@ -389,30 +389,30 @@ impl<Ret: RetTrait> Dfa<Ret> {
 
 impl<Ret: Debug> Debug for Dfa<Ret> {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
-        try!(f.write_fmt(format_args!("Dfa ({} states):\n", self.states.len())));
+        f.write_fmt(format_args!("Dfa ({} states):\n", self.states.len()))?;
 
-        try!(f.write_fmt(format_args!("Init: {:?}\n", self.init)));
+        f.write_fmt(format_args!("Init: {:?}\n", self.init))?;
 
         for (st_idx, st) in self.states.iter().enumerate().take(40) {
-            try!(f.write_fmt(format_args!("\tState {} (accepting: {:?}):\n", st_idx, st.accept)));
+            f.write_fmt(format_args!("\tState {} (accepting: {:?}):\n", st_idx, st.accept))?;
             if let Some(ref ret) = st.ret {
-                try!(f.write_fmt(format_args!("\t\t{:?}\n", ret)));
+                f.write_fmt(format_args!("\t\t{:?}\n", ret))?;
             }
 
             if !st.transitions.is_empty() {
-                try!(f.write_str("\t\tTransitions:\n"));
+                f.write_str("\t\tTransitions:\n")?;
                 // Cap it at 5 transitions, since it gets unreadable otherwise.
                 for &(range, target) in st.transitions.ranges_values().take(5) {
-                    try!(f.write_fmt(format_args!("\t\t\t{} -- {} => {}\n",
-                                                  range.start, range.end, target)));
+                    f.write_fmt(format_args!("\t\t\t{} -- {} => {}\n",
+                                                  range.start, range.end, target))?;
                 }
                 if st.transitions.num_ranges() > 5 {
-                    try!(f.write_str("\t\t\t...\n"));
+                    f.write_str("\t\t\t...\n")?;
                 }
             }
         }
         if self.states.len() > 40 {
-            try!(f.write_fmt(format_args!("\t...({} more states)\n", self.states.len() - 40)));
+            f.write_fmt(format_args!("\t...({} more states)\n", self.states.len() - 40))?;
         }
         Ok(())
     }
@@ -420,26 +420,26 @@ impl<Ret: Debug> Debug for Dfa<Ret> {
 
 #[cfg(test)]
 pub mod tests {
-    use dfa::*;
+    use crate::dfa::*;
     use itertools::Itertools;
-    use look::Look;
-    use nfa::{Accept, Nfa, StateIdx};
+    use crate::look::Look;
+    use crate::nfa::{Accept, Nfa, StateIdx};
     use range_map::{Range, RangeMap};
     use std::usize;
 
     // Creates a non-backtracking dfa from a regex string.
-    pub fn make_dfa_bounded(re: &str, max_states: usize) -> ::Result<Dfa<(Look, u8)>> {
-        let nfa = try!(Nfa::from_regex(re));
+    pub fn make_dfa_bounded(re: &str, max_states: usize) -> crate::Result<Dfa<(Look, u8)>> {
+        let nfa = (Nfa::from_regex(re)?);
         let nfa = nfa.remove_looks();
         println!("after remove_looks: {:?}", nfa);
-        let nfa = try!(nfa.byte_me(max_states));
+        let nfa = (nfa.byte_me(max_states)?);
         println!("after byte: {:?}", nfa);
 
-        let dfa = try!(nfa.determinize(max_states));
+        let dfa = (nfa.determinize(max_states)?);
         Ok(dfa.optimize())
     }
 
-    pub fn make_dfa(re: &str) -> ::Result<Dfa<(Look, u8)>> {
+    pub fn make_dfa(re: &str) -> crate::Result<Dfa<(Look, u8)>> {
         make_dfa_bounded(re, usize::MAX)
     }
 

--- a/src/dfa/prefix_searcher.rs
+++ b/src/dfa/prefix_searcher.rs
@@ -128,6 +128,8 @@ impl PrefixSearcher {
 // state. That sequence need not necessarily correspond to a unique path in the DFA, however.
 // Therefore, we store the sequence of bytes and also a set of possible paths that we might have
 // traversed while reading those bytes.
+// This code is kept for potential future use
+#[allow(dead_code)]
 #[derive(Clone, Debug, PartialEq)]
 pub struct CriticalSegment {
     bytes: Vec<u8>,
@@ -136,6 +138,7 @@ pub struct CriticalSegment {
 
 // The stdlib seems to have searching functions for &str, but not for &[u8]. If they get added, we
 // can remove this.
+#[allow(dead_code)]
 fn find(haystack: &[u8], needle: &[u8]) -> Option<usize> {
     haystack.windows(needle.len())
         .enumerate()

--- a/src/dfa/prefix_searcher.rs
+++ b/src/dfa/prefix_searcher.rs
@@ -6,9 +6,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use dfa::{Dfa, RetTrait};
-use dfa::trie::Trie;
-use nfa::{Accept, StateIdx};
+use crate::dfa::{Dfa, RetTrait};
+use crate::dfa::trie::Trie;
+use crate::nfa::{Accept, StateIdx};
 use std::cmp::{Ordering, PartialOrd};
 use std::collections::{HashSet, VecDeque};
 use std::mem::swap;
@@ -239,8 +239,8 @@ where I: Iterator<Item=&'a [u8]>, J: Iterator<Item=&'a [u8]> {
 
 #[cfg(test)]
 mod tests {
-    use dfa;
-    use look::Look;
+    use crate::dfa;
+    use crate::look::Look;
     use quickcheck::{QuickCheck, quickcheck, StdGen, TestResult};
     use rand;
     use super::*;

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,13 +17,12 @@ pub enum Error {
     InvalidEngine(&'static str),
 }
 
-use error::Error::*;
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            RegexSyntax(ref e) => write!(f, "Regex syntax error: {}", e),
-            TooManyStates => write!(f, "State overflow"),
-            InvalidEngine(s) => write!(f, "Invalid engine: {}", s),
+            Error::RegexSyntax(ref e) => write!(f, "Regex syntax error: {}", e),
+            Error::TooManyStates => write!(f, "State overflow"),
+            Error::InvalidEngine(s) => write!(f, "Invalid engine: {}", s),
         }
     }
 }
@@ -31,16 +30,16 @@ impl fmt::Display for Error {
 impl error::Error for Error {
     fn description(&self) -> &str {
         match *self {
-            RegexSyntax(ref e) => e.description(),
-            TooManyStates => "This NFA required too many states to represent as a DFA.",
-            InvalidEngine(_) => "The regex was not compatible with the requested engine.",
+            Error::RegexSyntax(_) => "Regex syntax error",
+            Error::TooManyStates => "This NFA required too many states to represent as a DFA.",
+            Error::InvalidEngine(_) => "The regex was not compatible with the requested engine.",
         }
     }
 }
 
 impl From<regex_syntax::Error> for Error {
     fn from(e: regex_syntax::Error) -> Error {
-        RegexSyntax(e)
+        Error::RegexSyntax(e)
     }
 }
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -117,6 +117,7 @@ pub trait Graph {
     ///
     /// Instead of running on the full graph, runs on the graph where pairs in `cuts` are
     /// disconnected.
+    #[allow(dead_code)]
     fn dfs_with_cut<Inits, Cuts, Visit, Cycle>(
         &self,
         init: Inits,

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -6,8 +6,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use dfa::{Dfa, RetTrait};
-use nfa::{Nfa, NoLooks, StateIdx};
+use crate::dfa::{Dfa, RetTrait};
+use crate::nfa::{Nfa, NoLooks, StateIdx};
 use num_traits::PrimInt;
 use std::collections::HashSet;
 use std::fmt::Debug;
@@ -23,7 +23,7 @@ pub enum DfsInstruction {
 pub trait Graph {
     fn num_states(&self) -> usize;
 
-    fn neighbors<'a>(&'a self, i: StateIdx) -> Box<Iterator<Item=StateIdx> + 'a>;
+    fn neighbors<'a>(&'a self, i: StateIdx) -> Box<dyn Iterator<Item=StateIdx> + 'a>;
 
     /// Does a depth-first search of this graph.
     ///
@@ -41,7 +41,7 @@ pub trait Graph {
     {
         // Pairs of (state, children_left_to_explore).
         let mut stack: Vec<StateIdx> = Vec::with_capacity(self.num_states());
-        let mut remaining_children_stack: Vec<Box<Iterator<Item=StateIdx>>>
+        let mut remaining_children_stack: Vec<Box<dyn Iterator<Item=StateIdx>>>
             = Vec::with_capacity(self.num_states());
         let mut visiting: Vec<bool> = vec![false; self.num_states()];
         let mut done: Vec<bool> = vec![false; self.num_states()];
@@ -165,7 +165,7 @@ impl<T: RetTrait> Graph for Dfa<T> {
         Dfa::num_states(self)
     }
 
-    fn neighbors<'a>(&'a self, i: StateIdx) -> Box<Iterator<Item=StateIdx> + 'a> {
+    fn neighbors<'a>(&'a self, i: StateIdx) -> Box<dyn Iterator<Item=StateIdx> + 'a> {
         Box::new(self.transitions(i).ranges_values().map(|x| x.1))
     }
 }
@@ -175,15 +175,15 @@ impl<Tok: Debug + PrimInt> Graph for Nfa<Tok, NoLooks> {
         Nfa::num_states(self)
     }
 
-    fn neighbors<'a>(&'a self, i: usize) -> Box<Iterator<Item=usize> + 'a> {
+    fn neighbors<'a>(&'a self, i: usize) -> Box<dyn Iterator<Item=usize> + 'a> {
         Box::new(self.consuming(i).ranges_values().map(|x| x.1))
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use dfa::tests::make_dfa;
-    use graph::Graph;
+    use crate::dfa::tests::make_dfa;
+    use crate::graph::Graph;
 
     #[test]
     fn cycles() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@ sense to do it all at the program's compile time. This feature will probably wai
 compiler plugin story stabilizes a bit.
 */
 
-#![cfg_attr(test, feature(test))]
+//#![cfg_attr(test, feature(test))]  // Disabled for stable Rust
 #[cfg(test)]
 extern crate quickcheck;
 
@@ -69,14 +69,13 @@ extern crate matches;
 #[cfg(test)]
 extern crate rand;
 
-#[cfg(test)]
-extern crate test;
+// #[cfg(test)]
+// extern crate test;  // Disabled - requires nightly for benchmarks
 
 extern crate itertools;
 extern crate memchr;
 extern crate num_traits;
 extern crate range_map;
-extern crate refinery;
 extern crate regex_syntax;
 extern crate utf8_ranges;
 
@@ -88,11 +87,12 @@ mod error;
 mod look;
 mod graph;
 mod nfa;
+mod partition;
 mod regex;
 mod runner;
 mod unicode;
 
 pub use error::Error;
 pub use regex::Regex;
-pub type Result<T> = ::std::result::Result<T, Error>;
+pub type Result<T> = std::result::Result<T, Error>;
 

--- a/src/look.rs
+++ b/src/look.rs
@@ -10,7 +10,7 @@
 
 use range_map::{Range, RangeSet};
 use std::cmp::Ordering;
-use unicode::PERLW;
+use crate::unicode::PERLW;
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Ord)]
 pub enum Look {
@@ -145,7 +145,7 @@ mod tests {
 
     impl Arbitrary for Look {
         fn arbitrary<G: Gen>(g: &mut G) -> Look {
-            use look::Look::*;
+            use Look::*;
 
             *g.choose(&[Full, WordChar, NotWordChar, NewLine, Boundary, Empty]).unwrap()
         }

--- a/src/nfa/has_looks.rs
+++ b/src/nfa/has_looks.rs
@@ -130,8 +130,8 @@
 //! non-consuming transition leads to an accepting state, it means that the source of that
 //! transition should become a conditionally accepting state.
 
-use look::Look;
-use nfa::{Accept, HasLooks, LookPair, Nfa, NoLooks, StateIdx};
+use crate::look::Look;
+use crate::nfa::{Accept, HasLooks, LookPair, Nfa, NoLooks, StateIdx};
 use std::cmp::max;
 use std::collections::HashSet;
 use std::ops::Deref;
@@ -163,8 +163,8 @@ impl Nfa<u32, HasLooks> {
     }
 
     /// Creates a new Nfa from a regex string.
-    pub fn from_regex(re: &str) -> ::Result<Nfa<u32, HasLooks>> {
-        let expr = try!(Expr::parse(re));
+    pub fn from_regex(re: &str) -> crate::Result<Nfa<u32, HasLooks>> {
+        let expr = (Expr::parse(re)?);
         let mut ret = Nfa::new();
 
         ret.add_state(Accept::Never);
@@ -542,9 +542,9 @@ impl Nfa<u32, HasLooks> {
 
 #[cfg(test)]
 mod tests {
-    use look::Look;
-    use nfa::{Accept, NoLooks, Nfa, StateIdx};
-    use nfa::tests::{re_nfa, trans_nfa};
+    use crate::look::Look;
+    use crate::nfa::{Accept, NoLooks, Nfa, StateIdx};
+    use crate::nfa::tests::{re_nfa, trans_nfa};
 
     // Creates an Nfa with the given transitions, with initial state zero, and with the final
     // state the only accepting state.

--- a/src/nfa/has_looks.rs
+++ b/src/nfa/has_looks.rs
@@ -132,7 +132,6 @@
 
 use crate::look::Look;
 use crate::nfa::{Accept, HasLooks, LookPair, Nfa, NoLooks, StateIdx};
-use std::cmp::max;
 use std::collections::HashSet;
 use std::ops::Deref;
 use range_map::{Range, RangeSet};
@@ -164,7 +163,7 @@ impl Nfa<u32, HasLooks> {
 
     /// Creates a new Nfa from a regex string.
     pub fn from_regex(re: &str) -> crate::Result<Nfa<u32, HasLooks>> {
-        let expr = (Expr::parse(re)?);
+        let expr = Expr::parse(re)?;
         let mut ret = Nfa::new();
 
         ret.add_state(Accept::Never);

--- a/src/nfa/mod.rs
+++ b/src/nfa/mod.rs
@@ -6,7 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use look::Look;
+use crate::look::Look;
 use num_traits::PrimInt;
 use range_map::{Range, RangeMultiMap};
 use std::fmt::{self, Debug, Formatter};
@@ -278,38 +278,38 @@ impl<Tok: Debug + PrimInt, L: Lookability> Nfa<Tok, L> {
 
 impl<Tok: Debug + PrimInt, L: Lookability> Debug for Nfa<Tok, L> {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        try!(f.write_fmt(format_args!("Nfa ({} states):\n", self.states.len())));
+        f.write_fmt(format_args!("Nfa ({} states):\n", self.states.len()))?;
 
-        try!(f.write_fmt(format_args!("Init: {:?}\n", self.init)));
+        f.write_fmt(format_args!("Init: {:?}\n", self.init))?;
 
         for (st_idx, st) in self.states.iter().enumerate().take(40) {
-            try!(f.write_fmt(format_args!("\tState {} ({:?}):\n", st_idx, st.accept)));
+            f.write_fmt(format_args!("\tState {} ({:?}):\n", st_idx, st.accept))?;
 
             if st.accept != Accept::Never {
-                try!(f.write_fmt(format_args!("\t\tlook {:?}, tokens {:?}, state {:?}\n",
-                                              st.accept_look, st.accept_tokens, st.accept_state)));
+                f.write_fmt(format_args!("\t\tlook {:?}, tokens {:?}, state {:?}\n",
+                                              st.accept_look, st.accept_tokens, st.accept_state))?;
             }
             if !st.consuming.is_empty() {
-                try!(f.write_str("\t\tConsuming:\n"));
+                f.write_str("\t\tConsuming:\n")?;
                 // Cap it at 10 transitions, since it gets unreadable otherwise.
                 for &(range, target) in st.consuming.ranges_values().take(10) {
-                    try!(f.write_fmt(format_args!("\t\t\t{:?} -- {:?} => {}\n",
-                                                  range.start, range.end, target)));
+                    f.write_fmt(format_args!("\t\t\t{:?} -- {:?} => {}\n",
+                                                  range.start, range.end, target))?;
                 }
                 if st.consuming.num_ranges() > 10 {
-                    try!(f.write_str("\t\t\t...\n"));
+                    f.write_str("\t\t\t...\n")?;
                 }
             }
             if !st.looking.is_empty() {
-                try!(f.write_str("\t\tLooking:\n"));
+                f.write_str("\t\tLooking:\n")?;
                 for look in &st.looking {
-                    try!(f.write_fmt(format_args!("\t\t\t({:?},{:?}) => {}\n",
-                        look.behind, look.ahead, look.target_state)));
+                    f.write_fmt(format_args!("\t\t\t({:?},{:?}) => {}\n",
+                        look.behind, look.ahead, look.target_state))?;
                 }
             }
         }
         if self.states.len() > 40 {
-            try!(f.write_fmt(format_args!("\t... ({} more states)\n", self.states.len() - 40)));
+            f.write_fmt(format_args!("\t... ({} more states)\n", self.states.len() - 40))?;
         }
         Ok(())
     }
@@ -317,7 +317,7 @@ impl<Tok: Debug + PrimInt, L: Lookability> Debug for Nfa<Tok, L> {
 
 #[cfg(test)]
 pub mod tests {
-    use nfa::{Accept, NoLooks, Nfa, StateIdx};
+    use crate::nfa::{Accept, NoLooks, Nfa, StateIdx};
     use num_traits::PrimInt;
     use range_map::Range;
     use std::fmt::Debug;

--- a/src/nfa/no_looks.rs
+++ b/src/nfa/no_looks.rs
@@ -6,11 +6,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use dfa::Dfa;
-use error::Error;
+use crate::dfa::Dfa;
+use crate::error::Error;
 use itertools::Itertools;
-use look::Look;
-use nfa::{Accept, Nfa, NoLooks, State, StateIdx, StateSet};
+use crate::look::Look;
+use crate::nfa::{Accept, Nfa, NoLooks, State, StateIdx, StateSet};
 use num_traits::PrimInt;
 use range_map::{Range, RangeMap, RangeMultiMap};
 use std::{char, u8, usize};
@@ -83,7 +83,7 @@ impl MergedUtf8Sequences {
         }
     }
 
-    fn from_sequences<'a, I>(iter: I) -> Box<Iterator<Item=MergedUtf8Sequences> + 'a>
+    fn from_sequences<'a, I>(iter: I) -> Box<dyn Iterator<Item=MergedUtf8Sequences> + 'a>
     where I: Iterator<Item=Utf8Sequence> + 'a {
         fn head(u: &Utf8Sequence) -> Vec<Utf8Range> {
             let len = u.len();
@@ -96,7 +96,7 @@ impl MergedUtf8Sequences {
             .map(|(_, seqs)| MergedUtf8Sequences::merge(seqs.into_iter())))
     }
 
-    fn from_ranges<'a, I>(iter: I) -> Box<Iterator<Item=MergedUtf8Sequences> + 'a>
+    fn from_ranges<'a, I>(iter: I) -> Box<dyn Iterator<Item=MergedUtf8Sequences> + 'a>
     where I: Iterator<Item=Range<u32>> + 'a {
         MergedUtf8Sequences::from_sequences(
             iter.filter_map(to_char_pair)
@@ -245,7 +245,7 @@ impl<Tok: Debug + PrimInt> Nfa<Tok, NoLooks> {
 
 impl Nfa<u32, NoLooks> {
     /// Converts this `Nfa` into one that consumes the input byte-by-byte.
-    pub fn byte_me(self, max_states: usize) -> ::Result<Nfa<u8, NoLooks>> {
+    pub fn byte_me(self, max_states: usize) -> crate::Result<Nfa<u8, NoLooks>> {
         let mut ret = Nfa::<u8, NoLooks> {
             states: self.states.iter().map(|s| State {
                 accept: s.accept,
@@ -264,7 +264,7 @@ impl Nfa<u32, NoLooks> {
             // can merge a bunch of Utf8Sequences before adding them, which saves a bunch of
             // states.
             for (tgt, transitions) in state.consuming.ranges_values().group_by(|x| x.1) {
-                try!(ret.add_utf8_sequences(i, transitions.into_iter().map(|x| x.0), tgt, max_states));
+                ret.add_utf8_sequences(i, transitions.into_iter().map(|x| x.0), tgt, max_states);
             }
         }
         Ok(ret)
@@ -273,7 +273,7 @@ impl Nfa<u32, NoLooks> {
 
 impl Nfa<u8, NoLooks> {
     /// Converts this `Nfa` into a `Dfa`.
-    pub fn determinize(&self, max_states: usize) -> ::Result<Dfa<(Look, u8)>> {
+    pub fn determinize(&self, max_states: usize) -> crate::Result<Dfa<(Look, u8)>> {
         Determinizer::determinize(self, max_states, MatchChoice::TransitionOrder, self.init.clone())
     }
 
@@ -282,7 +282,7 @@ impl Nfa<u8, NoLooks> {
     /// Whenever this `Nfa` matches some text, the `Dfa` also will. But if this `Nfa` has multiple
     /// possible endpoints for a match then the returned `Dfa` is only guaranteed to match the
     /// longest one.
-    pub fn determinize_longest(&self, max_states: usize) -> ::Result<Dfa<(Look, u8)>> {
+    pub fn determinize_longest(&self, max_states: usize) -> crate::Result<Dfa<(Look, u8)>> {
         Determinizer::determinize(self, max_states, MatchChoice::LongestMatch, self.init.clone())
     }
 
@@ -292,7 +292,7 @@ impl Nfa<u8, NoLooks> {
     /// the same strings of bytes reversed.
     ///
     /// Note that this loses information about match priorities.
-    pub fn reverse(&self, max_states: usize) -> ::Result<Nfa<u8, NoLooks>> {
+    pub fn reverse(&self, max_states: usize) -> crate::Result<Nfa<u8, NoLooks>> {
         let mut ret = self.reversed_simple();
 
         // Turn our initial states into ret's accepting states.
@@ -324,7 +324,7 @@ impl Nfa<u8, NoLooks> {
                         &REV_NOT_WORD_CHAR_DFA
                     };
                     let accept_state = ret.add_look_ahead_state(look, 1, i);
-                    try!(ret.add_min_utf8_sequences(i, dfa, accept_state, max_states));
+                    (ret.add_min_utf8_sequences(i, dfa, accept_state, max_states)?);
                 },
                 Look::Empty => {
                     panic!("Empty cannot be an init look");
@@ -355,7 +355,7 @@ impl Nfa<u8, NoLooks> {
     ///
     /// The result is actually a little bit different, because `.` matches a whole code point,
     /// whereas the `^.*` that we add works at the byte level.
-    pub fn anchor(mut self, max_states: usize) -> ::Result<Nfa<u8, NoLooks>> {
+    pub fn anchor(mut self, max_states: usize) -> crate::Result<Nfa<u8, NoLooks>> {
         let loop_accept = self.init_accept(Look::Full);
         let loop_state = self.add_state(loop_accept);
         let init_accept = self.init_accept(Look::Boundary);
@@ -388,8 +388,8 @@ impl Nfa<u8, NoLooks> {
                     let dfa: &Dfa<_> =
                         if look == Look::WordChar { &WORD_CHAR_DFA } else { &NOT_WORD_CHAR_DFA };
 
-                    try!(self.add_min_utf8_sequences(loop_state, dfa, st_idx, max_states));
-                    try!(self.add_min_utf8_sequences(init_state, dfa, st_idx, max_states));
+                    (self.add_min_utf8_sequences(loop_state, dfa, st_idx, max_states)?);
+                    (self.add_min_utf8_sequences(init_state, dfa, st_idx, max_states)?);
                 },
                 Look::Empty => {
                     panic!("Cannot start with an empty look");
@@ -437,7 +437,7 @@ impl Nfa<u8, NoLooks> {
         dfa: &Dfa<(Look, u8)>,
         end_state: StateIdx,
         max_states: usize,
-    ) -> ::Result<()> {
+    ) -> crate::Result<()> {
         let offset = self.states.len();
         // If end_accept is true, then it isn't actually important that we end in state
         // `end_state`: we can create a new look_ahead state to end in.
@@ -506,7 +506,7 @@ impl Nfa<u8, NoLooks> {
         ranges: I,
         end_state: StateIdx,
         max_states: usize
-    ) -> ::Result<()>
+    ) -> crate::Result<()>
     where I: Iterator<Item=Range<u32>> {
         for m in MergedUtf8Sequences::from_ranges(ranges) {
             self.add_utf8_sequence(start_state, end_state, m);
@@ -573,9 +573,9 @@ impl<'a> Determinizer<'a> {
     fn determinize(nfa: &Nfa<u8, NoLooks>,
                    max_states: usize,
                    match_choice: MatchChoice,
-                   init: Vec<(Look, StateIdx)>) -> ::Result<Dfa<(Look, u8)>> {
+                   init: Vec<(Look, StateIdx)>) -> crate::Result<Dfa<(Look, u8)>> {
         let mut det = Determinizer::new(nfa, max_states, match_choice);
-        try!(det.run(init));
+        (det.run(init)?);
         Ok(det.dfa)
     }
 
@@ -652,7 +652,7 @@ impl<'a> Determinizer<'a> {
     //
     // If the state already exists, returns the index of the old one. If there are too many states,
     // returns an error.
-    fn add_state(&mut self, mut s: StateSet) -> ::Result<StateIdx> {
+    fn add_state(&mut self, mut s: StateSet) -> crate::Result<StateIdx> {
         // When we choose our matches by transition order, discard any states that have lower
         // priority than the best match we've found.
         if self.match_choice == MatchChoice::TransitionOrder {
@@ -678,7 +678,7 @@ impl<'a> Determinizer<'a> {
 
     // Creates a deterministic automaton representing the same language as our `nfa`.
     // Puts the new Dfa in self.dfa.
-    fn run(&mut self, init: Vec<(Look, StateIdx)>) -> ::Result<()> {
+    fn run(&mut self, init: Vec<(Look, StateIdx)>) -> crate::Result<()> {
         if self.nfa.states.is_empty() {
             return Ok(());
         }
@@ -689,7 +689,7 @@ impl<'a> Determinizer<'a> {
                 .map(|(_, y)| y)
                 .collect();
             if !init_states.is_empty() {
-                let new_state_idx = try!(self.add_state(init_states));
+                let new_state_idx = (self.add_state(init_states)?);
                 self.dfa.init[look.as_usize()] = Some(new_state_idx);
             }
         }
@@ -702,7 +702,7 @@ impl<'a> Determinizer<'a> {
 
             let mut dfa_trans = Vec::new();
             for &(range, ref target) in trans.ranges_values() {
-                let target_idx = try!(self.add_state(target.clone()));
+                let target_idx = self.add_state(target.clone())?;
                 dfa_trans.push((range, target_idx));
             }
             self.dfa.set_transitions(state_idx, dfa_trans.into_iter().collect());
@@ -713,10 +713,10 @@ impl<'a> Determinizer<'a> {
 
 #[cfg(test)]
 mod tests {
-    use look::Look;
-    use dfa::Dfa;
-    use nfa::{Accept, Nfa, NoLooks};
-    use nfa::tests::{re_nfa, trans_nfa, trans_range_nfa};
+    use crate::look::Look;
+    use crate::dfa::Dfa;
+    use crate::nfa::{Accept, Nfa, NoLooks};
+    use crate::nfa::tests::{re_nfa, trans_nfa, trans_range_nfa};
     use range_map::Range;
     use std::usize;
 

--- a/src/nfa/no_looks.rs
+++ b/src/nfa/no_looks.rs
@@ -264,7 +264,7 @@ impl Nfa<u32, NoLooks> {
             // can merge a bunch of Utf8Sequences before adding them, which saves a bunch of
             // states.
             for (tgt, transitions) in state.consuming.ranges_values().group_by(|x| x.1) {
-                ret.add_utf8_sequences(i, transitions.into_iter().map(|x| x.0), tgt, max_states);
+                ret.add_utf8_sequences(i, transitions.into_iter().map(|x| x.0), tgt, max_states)?;
             }
         }
         Ok(ret)
@@ -689,7 +689,7 @@ impl<'a> Determinizer<'a> {
                 .map(|(_, y)| y)
                 .collect();
             if !init_states.is_empty() {
-                let new_state_idx = (self.add_state(init_states)?);
+                let new_state_idx = self.add_state(init_states)?;
                 self.dfa.init[look.as_usize()] = Some(new_state_idx);
             }
         }

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -1,0 +1,217 @@
+// Copyright 2015 Joe Neeman.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Vendored copy of the old `refinery` crate's Partition implementation.
+//!
+//! This crate implements a simple and fast algorithm for building and refining a partition of the set
+//! `[0usize, n)`. The most important type is `Partition` and its most important function is `refine`,
+//! which refines the `Partition` according to some subset.
+
+use std::collections::HashSet;
+use std::fmt::{Debug, Error, Formatter};
+use std::usize;
+
+/// A partition of a set of `usize`s.
+#[derive(Clone)]
+pub struct Partition {
+    // Contains the numbers 0..n in some order.
+    elts: Vec<usize>,
+    // A list of non-overlapping ranges. If `partition[i] = (j, k)` then the `i`th set in our
+    // partition is `elts[j..k]`.
+    partition: Vec<(usize, usize)>,
+    // If `rev_partition[i] == j` then `i` is in the `j`th set of our partition.
+    rev_partition: Vec<usize>,
+    // If `rev_elts[i] == j` then `elts[j] = i`.
+    rev_elts: Vec<usize>,
+
+    // Some extra space that we allocate up front so that we don't need to allocate in our inner
+    // loop. These are all modified during refinement.
+
+    // This stores indices of all parts that intersect with the set we are currently refining with.
+    active_sets: HashSet<usize>,
+    // For every index in `active_sets`, this stores an index into elts. It points to the first
+    // element in the difference between the refining set and the part.
+    diff_start: Vec<usize>,
+}
+
+/// An iterator over the sets in a `Partition`.
+#[derive(Clone, Debug)]
+pub struct PartitionIter<'a> {
+    next_set_idx: usize,
+    partition: &'a Partition,
+}
+
+impl Partition {
+    /// Constructs a new `Partition`.
+    ///
+    /// `sets` is an iterator over the sets of the partition. The sets must be non-overlapping, and
+    /// they must all be subsets of the half-open range `[0, size)`.
+    ///
+    /// # Panics
+    ///  - if any sets overlap
+    ///  - if any sets contain an element larger than or equal to `size`.
+    pub fn new<I, J>(sets: I, size: usize) -> Partition
+    where I: Iterator<Item=J>, J: Iterator<Item=usize> {
+        let mut ret = Partition {
+            elts: Vec::with_capacity(size),
+            partition: Vec::with_capacity(size),
+            rev_partition: vec![usize::MAX; size],
+            rev_elts: vec![usize::MAX; size],
+            active_sets: HashSet::with_capacity(size),
+            diff_start: vec![usize::MAX; size],
+        };
+
+        for set in sets {
+            let set_idx = ret.partition.len();
+            let set_start = ret.elts.len();
+            for item in set {
+                if item >= size {
+                    panic!("all set elements must be smaller than `size`");
+                } else if ret.rev_partition[item] != usize::MAX {
+                    panic!("the element {} was repeated", item);
+                } else {
+                    ret.elts.push(item);
+                    ret.rev_partition[item] = set_idx;
+                    ret.rev_elts[item] = ret.elts.len() - 1;
+                }
+            }
+            ret.partition.push((set_start, ret.elts.len()));
+        }
+
+        ret
+    }
+
+    /// Iterates over the sets in this partition, each of which is realized by a `&[usize]`.
+    pub fn iter(&self) -> PartitionIter {
+        PartitionIter {
+            next_set_idx: 0,
+            partition: self,
+        }
+    }
+
+    /// Refines the partition with the given set.
+    ///
+    /// Every set `s` in the partition is replaced by `s.intersection(refiner)` and
+    /// `s.difference(refiner)`.
+    ///
+    /// This function runs in time that is O(n log n) in the size of `refiner`.
+    ///
+    /// # Panics
+    ///  - if `refiner` contains any elements that are not in the partition
+    pub fn refine(&mut self, refiner: &[usize]) {
+        self.refine_with_callback(refiner, |_, _, _| {});
+    }
+
+    /// Returns one part of this partition.
+    pub fn part(&self, part_idx: usize) -> &[usize] {
+        let (start, end) = self.partition[part_idx];
+        &self.elts[start..end]
+    }
+
+    /// The number of parts in this partition.
+    pub fn num_parts(&self) -> usize {
+        self.partition.len()
+    }
+
+    /// Refines the partition with the given set.
+    ///
+    /// Every set `s` in the partition is replaced by `s.intersection(refiner)` and
+    /// `s.difference(refiner)`. Every time we make such a non-trivial (meaning that both the
+    /// intersection and the difference are non-empty) replacement, we call the supplied callback
+    /// function with arguments `self`, `original_set_idx` and `difference_idx`.
+    ///
+    /// This function runs in time that is O(n log n) in the size of `refiner`.
+    ///
+    /// # Panics
+    ///  - if `refiner` contains any elements that are not in the partition
+    pub fn refine_with_callback<F>(&mut self, refiner: &[usize], mut split_callback: F)
+    where F: FnMut(&Partition, usize, usize) {
+        self.active_sets.clear();
+        for &x in refiner.iter() {
+            if x >= self.rev_partition.len() {
+                panic!("`refiner` went out of bounds: {:?}", refiner);
+            } else if self.rev_partition[x] == usize::MAX {
+                panic!("`refiner contained an element ({:?}) that wasn't in the initial partition", x);
+            }
+
+            let part_idx = self.rev_partition[x];
+            if self.active_sets.insert(part_idx) {
+                // We start out saying that everything is in the difference (part \ refiner).
+                self.diff_start[part_idx] = self.partition[part_idx].0;
+            }
+
+            let old_x_idx = self.rev_elts[x];
+            let old_y_idx = self.diff_start[part_idx];
+            let y = self.elts[old_y_idx];
+            self.elts.swap(old_x_idx, old_y_idx);
+            self.diff_start[part_idx] += 1;
+
+            self.rev_elts[x] = old_y_idx;
+            self.rev_elts[y] = old_x_idx;
+        }
+
+        // Go over the active sets and see which of them were actually split non-trivially.
+        for &part_idx in &self.active_sets {
+            let (start, end) = self.partition[part_idx];
+            let diff_start = self.diff_start[part_idx];
+
+            if diff_start != start && diff_start != end {
+                // There was a non-trivial split. The intersection is in [start, diff_start). The
+                // difference is in [diff_start, end).
+                self.partition[part_idx] = (start, diff_start);
+                self.partition.push((diff_start, end));
+                for elt_idx in diff_start..end {
+                    let elt = self.elts[elt_idx];
+                    self.rev_partition[elt] = self.partition.len() - 1;
+                    self.rev_elts[elt] = elt_idx;
+                }
+
+                split_callback(self, part_idx, self.partition.len() - 1);
+            }
+        }
+    }
+}
+
+// This only exists so we can give a `Debug` impl that displays a slice like a set.
+struct SliceSet<'a>(&'a [usize]);
+
+impl<'a> Debug for SliceSet<'a> {
+    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+        fmt.debug_set().entries(self.0.iter()).finish()
+    }
+}
+
+impl Debug for Partition {
+    fn fmt(&self, fmt: &mut Formatter) -> Result<(), Error> {
+        fmt.debug_set()
+            .entries(self.partition.iter()
+                     .map(|&(start, end)| { SliceSet(&self.elts[start..end]) }))
+            .finish()
+    }
+}
+
+impl<'a> Iterator for PartitionIter<'a> {
+    type Item = &'a [usize];
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.next_set_idx < self.partition.partition.len() {
+            let (start, end) = self.partition.partition[self.next_set_idx];
+            self.next_set_idx += 1;
+            Some(&self.partition.elts[start..end])
+        } else {
+            None
+        }
+    }
+}
+
+impl<'a> IntoIterator for &'a Partition {
+    type Item = &'a [usize];
+    type IntoIter = PartitionIter<'a>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -87,7 +87,7 @@ impl Partition {
     }
 
     /// Iterates over the sets in this partition, each of which is realized by a `&[usize]`.
-    pub fn iter(&self) -> PartitionIter {
+    pub fn iter(&self) -> PartitionIter<'_> {
         PartitionIter {
             next_set_idx: 0,
             partition: self,

--- a/src/regex.rs
+++ b/src/regex.rs
@@ -6,17 +6,17 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use error::Error;
-use nfa::{Nfa, NoLooks};
-use runner::anchored::AnchoredEngine;
-use runner::forward_backward::{ForwardBackwardEngine, Prefix};
-use runner::Engine;
+use crate::error::Error;
+use crate::nfa::{Nfa, NoLooks};
+use crate::runner::anchored::AnchoredEngine;
+use crate::runner::forward_backward::{ForwardBackwardEngine, Prefix};
+use crate::runner::Engine;
 use std;
 use std::fmt::Debug;
 
 #[derive(Debug)]
 pub struct Regex {
-    engine: Box<Engine<u8>>,
+    engine: Box<dyn Engine<u8>>,
 }
 
 // An engine that doesn't match anything.
@@ -25,7 +25,7 @@ struct EmptyEngine;
 
 impl<Ret: Debug> Engine<Ret> for EmptyEngine {
     fn find(&self, _: &str) -> Option<(usize, usize, Ret)> { None }
-    fn clone_box(&self) -> Box<Engine<Ret>> { Box::new(EmptyEngine) }
+    fn clone_box(&self) -> Box<dyn Engine<Ret>> { Box::new(EmptyEngine) }
 }
 
 impl Clone for Regex {
@@ -38,31 +38,31 @@ impl Clone for Regex {
 
 impl Regex {
     /// Creates a new `Regex` from a regular expression string.
-    pub fn new(re: &str) -> ::Result<Regex> {
+    pub fn new(re: &str) -> crate::Result<Regex> {
         Regex::new_bounded(re, std::usize::MAX)
     }
 
     /// Creates a new `Regex` from a regular expression string, but only if it doesn't require too
     /// many states.
-    pub fn new_bounded(re: &str, max_states: usize) -> ::Result<Regex> {
-        let nfa = try!(Nfa::from_regex(re));
+    pub fn new_bounded(re: &str, max_states: usize) -> crate::Result<Regex> {
+        let nfa = (Nfa::from_regex(re)?);
         let nfa = nfa.remove_looks();
 
         let eng = if nfa.is_empty() {
-            Box::new(EmptyEngine) as Box<Engine<u8>>
+            Box::new(EmptyEngine) as Box<dyn Engine<u8>>
         } else if nfa.is_anchored() {
-            Box::new(try!(Regex::make_anchored(nfa, max_states))) as Box<Engine<u8>>
+            Box::new((Regex::make_anchored(nfa, max_states)?)) as Box<dyn Engine<u8>>
         } else {
-            Box::new(try!(Regex::make_forward_backward(nfa, max_states))) as Box<Engine<u8>>
+            Box::new((Regex::make_forward_backward(nfa, max_states)?)) as Box<dyn Engine<u8>>
         };
 
         Ok(Regex { engine: eng })
     }
 
     fn make_anchored(nfa: Nfa<u32, NoLooks>, max_states: usize)
-    -> ::Result<AnchoredEngine<u8>> {
-        let nfa = try!(nfa.byte_me(max_states));
-        let dfa = try!(nfa.determinize(max_states))
+    -> crate::Result<AnchoredEngine<u8>> {
+        let nfa = (nfa.byte_me(max_states)?);
+        let dfa = (nfa.determinize(max_states)?)
             .optimize()
             .map_ret(|(_, bytes)| bytes);
         let prog = dfa.compile();
@@ -71,16 +71,16 @@ impl Regex {
     }
 
     fn make_forward_backward(nfa: Nfa<u32, NoLooks>, max_states: usize)
-    -> ::Result<ForwardBackwardEngine<u8>> {
+    -> crate::Result<ForwardBackwardEngine<u8>> {
         if nfa.is_anchored() {
             return Err(Error::InvalidEngine("anchors rule out the forward-backward engine"));
         }
 
-        let f_nfa = try!(try!(nfa.clone().byte_me(max_states)).anchor(max_states));
-        let b_nfa = try!(try!(nfa.byte_me(max_states)).reverse(max_states));
+        let f_nfa = nfa.clone().byte_me(max_states)?.anchor(max_states)?;
+        let b_nfa = nfa.byte_me(max_states)?.reverse(max_states)?;
 
-        let f_dfa = try!(f_nfa.determinize(max_states)).optimize();
-        let b_dfa = try!(b_nfa.determinize_longest(max_states)).optimize();
+        let f_dfa = f_nfa.determinize(max_states)?.optimize();
+        let b_dfa = b_nfa.determinize_longest(max_states)?.optimize();
         let b_dfa = b_dfa.map_ret(|(_, bytes)| bytes);
 
         let b_prog = b_dfa.compile();

--- a/src/regex.rs
+++ b/src/regex.rs
@@ -45,15 +45,15 @@ impl Regex {
     /// Creates a new `Regex` from a regular expression string, but only if it doesn't require too
     /// many states.
     pub fn new_bounded(re: &str, max_states: usize) -> crate::Result<Regex> {
-        let nfa = (Nfa::from_regex(re)?);
+        let nfa = Nfa::from_regex(re)?;
         let nfa = nfa.remove_looks();
 
         let eng = if nfa.is_empty() {
             Box::new(EmptyEngine) as Box<dyn Engine<u8>>
         } else if nfa.is_anchored() {
-            Box::new((Regex::make_anchored(nfa, max_states)?)) as Box<dyn Engine<u8>>
+            Box::new(Regex::make_anchored(nfa, max_states)?) as Box<dyn Engine<u8>>
         } else {
-            Box::new((Regex::make_forward_backward(nfa, max_states)?)) as Box<dyn Engine<u8>>
+            Box::new(Regex::make_forward_backward(nfa, max_states)?) as Box<dyn Engine<u8>>
         };
 
         Ok(Regex { engine: eng })
@@ -61,7 +61,7 @@ impl Regex {
 
     fn make_anchored(nfa: Nfa<u32, NoLooks>, max_states: usize)
     -> crate::Result<AnchoredEngine<u8>> {
-        let nfa = (nfa.byte_me(max_states)?);
+        let nfa = nfa.byte_me(max_states)?;
         let dfa = (nfa.determinize(max_states)?)
             .optimize()
             .map_ret(|(_, bytes)| bytes);

--- a/src/runner/anchored.rs
+++ b/src/runner/anchored.rs
@@ -7,8 +7,8 @@
 // except according to those terms.
 
 use std::fmt::Debug;
-use runner::Engine;
-use runner::program::TableInsts;
+use crate::runner::Engine;
+use crate::runner::program::TableInsts;
 
 #[derive(Clone, Debug)]
 pub struct AnchoredEngine<Ret> {
@@ -35,7 +35,7 @@ impl<Ret: Copy + Debug + 'static> Engine<Ret> for AnchoredEngine<Ret> {
         }
     }
 
-    fn clone_box(&self) -> Box<Engine<Ret>> {
+    fn clone_box(&self) -> Box<dyn Engine<Ret>> {
         Box::new(self.clone())
     }
 }

--- a/src/runner/forward_backward.rs
+++ b/src/runner/forward_backward.rs
@@ -8,11 +8,11 @@
 
 use std::fmt::Debug;
 //use dfa::{Dfa, PrefixPart, RetTrait};
-use dfa::PrefixPart;
+use crate::dfa::PrefixPart;
 use itertools::Itertools;
 use memchr::memchr;
-use runner::Engine;
-use runner::program::TableInsts;
+use crate::runner::Engine;
+use crate::runner::program::TableInsts;
 
 #[derive(Clone, Debug)]
 pub struct ForwardBackwardEngine<Ret> {
@@ -87,7 +87,7 @@ impl<Ret: Copy + Debug + 'static> Engine<Ret> for ForwardBackwardEngine<Ret> {
         }
     }
 
-    fn clone_box(&self) -> Box<Engine<Ret>> {
+    fn clone_box(&self) -> Box<dyn Engine<Ret>> {
         Box::new(self.clone())
     }
 }
@@ -198,7 +198,7 @@ impl Prefix {
 
 #[cfg(test)]
 mod tests {
-    use dfa::PrefixPart;
+    use crate::dfa::PrefixPart;
     use super::*;
 
     fn pref(strs: Vec<&str>) -> Prefix {

--- a/src/runner/mod.rs
+++ b/src/runner/mod.rs
@@ -2,7 +2,7 @@ use std::fmt::Debug;
 
 pub trait Engine<Ret: Debug>: Debug {
     fn find(&self, s: &str) -> Option<(usize, usize, Ret)>;
-    fn clone_box(&self) -> Box<Engine<Ret>>;
+    fn clone_box(&self) -> Box<dyn Engine<Ret>>;
 }
 
 pub mod anchored;

--- a/src/runner/program.rs
+++ b/src/runner/program.rs
@@ -39,36 +39,36 @@ pub struct TableInsts<Ret> {
 
 impl<Ret: Debug> Debug for TableInsts<Ret> {
     fn fmt(&self, f: &mut Formatter) -> Result<(), FmtError> {
-        try!(f.write_fmt(format_args!("TableInsts ({} log_classes, {} instructions):\n",
+        f.write_fmt(format_args!("TableInsts ({} log_classes, {} instructions)?:\n",
                                       self.log_num_classes,
-                                      self.accept.len())));
-        try!(f.write_str("Byte classes: "));
-        try!(f.debug_map()
+                                      self.accept.len()))?;
+        f.write_str("Byte classes: ")?;
+        f.debug_map()
             .entries((0..256).map(|b| (b, self.byte_class[b])))
-            .finish());
+            .finish()?;
 
         let num_classes = 1 << self.log_num_classes;
         for idx in 0..self.accept.len() {
-            try!(f.write_fmt(format_args!("State {}:\n", idx)));
-            try!(f.debug_map()
+            f.write_fmt(format_args!("State {}:\n", idx))?;
+            f.debug_map()
                 .entries((0usize..num_classes)
                     .map(|c| (c, self.table[(idx << self.log_num_classes) + c]))
                     .filter(|x| x.1 != u32::MAX))
-                .finish());
-            try!(f.write_str("\n"));
+                .finish()?;
+            f.write_str("\n")?;
         }
 
-        try!(f.write_str("Accept: "));
+        f.write_str("Accept: ")?;
         for idx in 0..self.accept.len() {
             if let Some(ref ret) = self.accept[idx] {
-                try!(f.write_fmt(format_args!("{} -> {:?}, ", idx, ret)));
+                f.write_fmt(format_args!("{} -> {:?}, ", idx, ret))?;
             }
         }
 
-        try!(f.write_str("Accept_at_eoi: "));
+        f.write_str("Accept_at_eoi: ")?;
         for idx in 0..self.accept_at_eoi.len() {
             if let Some(ref ret) = self.accept_at_eoi[idx] {
-                try!(f.write_fmt(format_args!("{} -> {:?}, ", idx, ret)));
+                f.write_fmt(format_args!("{} -> {:?}, ", idx, ret))?;
             }
         }
         Ok(())


### PR DESCRIPTION
The original codebase has been unmaintained for ~9 years and no longer compiles with modern Rust. This PR updates all deprecated syntax, resolves dependency conflicts, and ensures all tests pass on stable Rust.

All 45 library tests passing. Also removed warnings when building it.